### PR TITLE
✨ added whitelist slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "scripts": {
     "start": "npm run replica && npm run deploy && npm run mint",
-    "replica": "dfx stop && dfx start --clean --background",
+    "replica": "dfx stop && dfx start --clean --background && dfx canister create staging && dfx canister create ledger",
     "deploy": " npm run deploy:staging && npm run deploy:ledger",
     "deploy-qq": "npm run deploy:staging -- -qq && npm run deploy:ledger -- -qq",
     "deploy:staging": "dfx canister create staging && DFX_MOC_PATH=\"$(vessel bin)/moc\" dfx deploy staging --mode reinstall -y --argument '(principal \"'$(dfx canister id staging)'\")'",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "test:public-sale": "npm run env public-sale && npm run deploy-qq && npm run mint && vitest run public-sale",
     "test:highload-sale": "npm run env highload-sale && npm run deploy-qq && npm run mint && vitest run highload-sale",
     "test:whitelist-sale": "npm run env whitelist-sale && npm run deploy-qq && npm run mint && vitest run whitelist-sale",
+    "test:whitelist-slots": "npm run env whitelist-slots && npm run deploy-qq && npm run mint && vitest run whitelist-slots",
     "test:marketplace": "npm run env marketplace && npm run deploy-qq && npm run mint && vitest run marketplace",
     "test:fees": "npm run env fees && npm run deploy-qq && npm run mint && vitest run fees",
     "test:sold-out": "npm run env sold-out && npm run deploy-qq && npm run mint && vitest run sold-out",
-    "test": "npm run test:pending-sale && npm run test:public-sale && npm run test:highload-sale && npm run test:whitelist-sale && npm run test:marketplace && npm run test:fees && npm run test:sold-out"
+    "test": "npm run test:pending-sale && npm run test:public-sale && npm run test:highload-sale && npm run test:whitelist-sale && npm run test:whitelist-slots && npm run test:marketplace && npm run test:fees && npm run test:sold-out"
   },
   "devDependencies": {
     "@dfinity/agent": "^0.15.0",

--- a/src/Env/_template.mo
+++ b/src/Env/_template.mo
@@ -30,6 +30,22 @@ module {
   public let whitelistTime : Time.Time = $whitelistTime; // Period for WL only discount. Set to publicSaleStart for no exclusive period
   public let marketDelay : Time.Time = $marketDelay; // How long to delay market opening (2 days after whitelist sale started or when sold out)
 
+  public type WhitelistSlot = {
+    start : Time.Time;
+    end : Time.Time;
+  };
+
+  // this allows you to create slots for whitelists. one slots can contain multiple whitelist.
+  // the start of the first slot has to be the publicSaleStart, the end of the last slot the whitelistTime
+  let whitelistSlot1 = {
+    start = $whitelistSlot1_start;
+    end = $whitelistSlot1_end;
+  };
+  let whitelistSlot2 = {
+    start = $whitelistSlot2_start;
+    end = $whitelistSlot2_end;
+  };
+
   // true - assets will be revealed after manually calling 'shuffleAssets'
   // false - assets will be revealed immediately and assets shuffling will be disabled
   public let delayedReveal = $delayedReveal;
@@ -59,6 +75,7 @@ module {
     name : Text;
     price : Nat64;
     whitelist : [ExtCore.AccountIdentifier];
+    slot : WhitelistSlot;
   };
 
   // order from lower price to higher price
@@ -67,11 +84,13 @@ module {
       name = $whitelistTier0Name;
       price = $whitelistTier0Price;
       whitelist = $whitelistTier0Whitelist;
+      slot = whitelistSlot1;
     },
     {
       name = $whitelistTier1Name;
       price = $whitelistTier1Price;
       whitelist = $whitelistTier1Whitelist;
+      slot = whitelistSlot2;
     },
   ];
 };

--- a/src/Env/lib.mo
+++ b/src/Env/lib.mo
@@ -27,8 +27,24 @@ module {
   public let defaultMarketplaceFee = ("ccfe146bb249b6c59e8c5ae71a1b59ddf85d9f9034611427b696f8b25d7b826a", 1000 : Nat64); // Entrepot Fee
 
   public let publicSaleStart : Time.Time = 1677345064258000000; // Start of first purchase (WL or other)
-  public let whitelistTime : Time.Time = 1677345064258000000; // Period for WL only discount. Set to publicSaleStart for no exclusive period
+  public let whitelistTime : Time.Time = 1677345075058000000; // Period for WL only discount. Set to publicSaleStart for no exclusive period
   public let marketDelay : Time.Time = 172800000000000; // How long to delay market opening (2 days after whitelist sale started or when sold out)
+
+  public type WhitelistSlot = {
+    start : Time.Time;
+    end : Time.Time;
+  };
+
+  // this allows you to create slots for whitelists. one slots can contain multiple whitelist.
+  // the start of the first slot has to be the publicSaleStart, the end of the last slot the whitelistTime
+  let firstHour = {
+    start = publicSaleStart;
+    end = 1677345067858000000;
+  };
+  let secondHour = {
+    start = 1677345067858000000;
+    end = whitelistTime;
+  };
 
   // true - assets will be revealed after manually calling 'shuffleAssets'
   // false - assets will be revealed immediately and assets shuffling will be disabled
@@ -52,26 +68,29 @@ module {
 
   // Airdrop (only addresses, no token index anymore)
   public let airdropEnabled = false;
-  public let airdrop : [ExtCore.AccountIdentifier] = ["e66c26a7e1258984b84dfc92bbfca3084d4252abb0091ca6c1196df2acb18f9d","ae3dbb489190f52c7a9830bbd89e00da4eef57b1d6ca04ede55be4e6fcb61bf9","943fd89889433e9095cdfee0998e51b76c3e89ec96cb1b19b09c51dd60ef61d2","a0b0636cb7e5962c3f8b579d4eaea4fa5cf5bd2b7bca012f7edb4c8e22704a15","aaa8563d505d86d00721da1fc5e6ec6005306fb815aa480d12d82c066279bfd9","a8811f0497f397fc669783447e53a3ee62f58089b28ddbfe8cf4e91a5e37073e","1edf167a947719829359da03128db5b6d18b1c6e0e342df97a21110740fcd4e2","5c064042aa679a9faf58af1b9c4e696110ddfa0502dcafae6c88c333654f1e5c","1f2fa4e9a5e1ad1ded167e898b13693bfaa5f7e7021da33a6ed9f3f71d6c6efd","8ecad355c3bafd563621d50c54d7718f87c17f27b1da7d2b954ef0c8824ae552","8949adb95619f40749af2335822f3731dc5ed3f03c511f471f087a88d29c90a6","4727f8e0b8c54069fa11d08e8b8e8b44b135379729a19819fb6a5c8432ceca6e","61929645bdc5f4859fc22b2427205c07fbb07c5149f253632a7ed05bab0db8b1","12db85c8a60e716f3ea2aaf80ba0f0e674e673e9dbf70f17124bfd434eb2c2a1","a50e7c492cc7eda25664194fa4c612cb1de137de88d528e87f0d5f4b6875ec65","55445d5b6a4a850fe3896a7193c5da517ed6e97fd183e19452f6ff692a834c00","22cbdf6a68d58e954e396d3dfd5d279cc895095380a7ee8be941d50c922a9739","c90b990316a82945ec505fc81908cc07801deea6234cb2235cca6f533ca3155a","c48d08f41c4e9d583acd49d7f02f5f4ae8725fad969ff7539805f4d146916efc","f12e0e9913b343ab381f0c53e78fceb55f186ad587a9df8ba7090e81ed7834f7"];
+  public let airdrop : [ExtCore.AccountIdentifier] = ["e66c26a7e1258984b84dfc92bbfca3084d4252abb0091ca6c1196df2acb18f9d"];
 
   // whitelist tiers
   public type WhitelistTier = {
     name : Text;
     price : Nat64;
     whitelist : [ExtCore.AccountIdentifier];
+    slot : WhitelistSlot;
   };
 
-  // order from lower price to higher price
+  // order from slots and within slots by price
   public let whitelistTiers : [WhitelistTier] = [
     {
       name = "ethflower";
       price = 350000000;
-      whitelist = ["da1fae1e25a417ab70953983a0c83ae5d7ee68ea83b1ac7b291246a29c87cc04","d29028c05d4b3a4e54b2c9040dd6d5acf8d79308b28344898729a0de0a52b241","43bf49989a6ac24d7dc97c93cc9e8bfe2ac245cb61a93754c6cd816877a7e59e","67e748b7e98637e151e261306cb2a503a229f6b6fbac37bc7b29f67e5d3984a7","e2f3ea30711a84fc73be573dc190ce6cc1d823e3b66f5f2b801e08c0662287f2","022012e61adc127db33504a4184e06656c0f61a523775495917e5d9800d3755e","f08b37e12779213cb9009e5d002b3e6882bc4b25ff74c5fa495c5b59a8afa114","7768f524837c292350dc65d0dc9e3d74c4ecabdac079280af4ad300e67cc5c02","747b0cd2a9671ac975320eef57ab3a91bda305632a8e5cbb89fe48a494e9c3f7","4d3e6ffca4fa377c11ccedc34a3f1c394287a0a04387b2843eb6769923767d05","8949adb95619f40749af2335822f3731dc5ed3f03c511f471f087a88d29c90a6","4727f8e0b8c54069fa11d08e8b8e8b44b135379729a19819fb6a5c8432ceca6e","61929645bdc5f4859fc22b2427205c07fbb07c5149f253632a7ed05bab0db8b1","12db85c8a60e716f3ea2aaf80ba0f0e674e673e9dbf70f17124bfd434eb2c2a1","a50e7c492cc7eda25664194fa4c612cb1de137de88d528e87f0d5f4b6875ec65","55445d5b6a4a850fe3896a7193c5da517ed6e97fd183e19452f6ff692a834c00","22cbdf6a68d58e954e396d3dfd5d279cc895095380a7ee8be941d50c922a9739","c90b990316a82945ec505fc81908cc07801deea6234cb2235cca6f533ca3155a","c48d08f41c4e9d583acd49d7f02f5f4ae8725fad969ff7539805f4d146916efc","f12e0e9913b343ab381f0c53e78fceb55f186ad587a9df8ba7090e81ed7834f7"];
+      whitelist = ["da1fae1e25a417ab70953983a0c83ae5d7ee68ea83b1ac7b291246a29c87cc04"];
+      slot = firstHour;
     },
     {
       name = "modclub";
       price = 500000000;
-      whitelist = ["b35858170c410ce65ae3dc9d36298766aa36d287854fe43dcb65998f19bc5881","68b9a81e80a707742e8639d92e69e629734c1bd7da330a7bef67247f80ea72dc","e9a5963080ece74caa4f799f7edfb469383f489427c05baa0ce3936d3552bd69","1dcf2932101e2f4ab453eb8c6a4bac692f4698d02509482c982027b157627cd7","856b2784f3b293a0257a8250490f64b5bea7855158e440f433efa9fcb2aa93cc","5f2e86d837b90f6dbd38be922d3cbeee8bc5734e6f283fc7290c7fbd222ffdbc","25baafc61173510143682d577d4fe06a018ffbd304b97c16d72dcf7c76f90d9b","360ddd1c4bf11ecf74f9d4e5970b3074c760417d09b2167c4579d7f752e20de9","e6c13c6004b4e2ee4031b86be2a3a4312dfb367889cd83c0283bc8d29859e427","d00df7eab5e813fa15efc9fbc54fef6c3b22b7765210170fbdebe17dafb83876","8949adb95619f40749af2335822f3731dc5ed3f03c511f471f087a88d29c90a6","4727f8e0b8c54069fa11d08e8b8e8b44b135379729a19819fb6a5c8432ceca6e","61929645bdc5f4859fc22b2427205c07fbb07c5149f253632a7ed05bab0db8b1","12db85c8a60e716f3ea2aaf80ba0f0e674e673e9dbf70f17124bfd434eb2c2a1","a50e7c492cc7eda25664194fa4c612cb1de137de88d528e87f0d5f4b6875ec65","55445d5b6a4a850fe3896a7193c5da517ed6e97fd183e19452f6ff692a834c00","22cbdf6a68d58e954e396d3dfd5d279cc895095380a7ee8be941d50c922a9739","c90b990316a82945ec505fc81908cc07801deea6234cb2235cca6f533ca3155a","c48d08f41c4e9d583acd49d7f02f5f4ae8725fad969ff7539805f4d146916efc","f12e0e9913b343ab381f0c53e78fceb55f186ad587a9df8ba7090e81ed7834f7"];
+      whitelist = ["b35858170c410ce65ae3dc9d36298766aa36d287854fe43dcb65998f19bc5881"];
+      slot = secondHour;
     },
   ];
 };

--- a/src/Http/lib.mo
+++ b/src/Http/lib.mo
@@ -140,7 +140,7 @@ module {
 
       var whitelistTiersText = "";
       for (whitelistTier in Env.whitelistTiers.vals()) {
-        whitelistTiersText #= whitelistTier.name # " " # _displayICP(Nat64.toNat(whitelistTier.price)) # "; ";
+        whitelistTiersText #= whitelistTier.name # " " # _displayICP(Nat64.toNat(whitelistTier.price)) # "start: " # debug_show (whitelistTier.slot.start) # ", end: " # debug_show (whitelistTier.slot.end) # "; ";
       };
 
       return {

--- a/src/Sale/lib.mo
+++ b/src/Sale/lib.mo
@@ -366,13 +366,21 @@ module {
     };
 
     public func salesSettings(address : Types.AccountIdentifier) : Types.SaleSettings {
+      var startTime = Env.whitelistTime;
+      // for whitelisted user return nearest and cheapest slot start time
+      for (item in _whitelist.vals()) {
+        if (item.1 == address and Time.now() <= item.2.end) {
+          startTime := item.2.start;
+        };
+      };
+
       return {
         price = getAddressPrice(address);
         salePrice = Env.salePrice;
         remaining = availableTokens();
         sold = _sold;
         totalToSell = _totalToSell;
-        startTime = Env.publicSaleStart;
+        startTime = startTime;
         whitelistTime = Env.whitelistTime;
         whitelist = isWhitelisted(address);
         bulkPricing = getAddressBulkPrice(address);
@@ -422,7 +430,7 @@ module {
       // this method assumes the wl prices are added in ascending order, so the cheapest wl price in the earliest slot
       // is always the first one.
       for (item in _whitelist.vals()) {
-        if (item.1 == address and Time.now() >= item.2.start and Time.now() <= item.2.end) {
+        if (item.1 == address and Time.now() <= item.2.end) {
           return [(1, item.0)];
         };
       };

--- a/src/Sale/lib.mo
+++ b/src/Sale/lib.mo
@@ -422,7 +422,7 @@ module {
       // this method assumes the wl prices are added in ascending order, so the cheapest wl price in the earliest slot
       // is always the first one.
       for (item in _whitelist.vals()) {
-        if (item.1 == address and item.2.start >= Time.now() and item.2.end <= Time.now()) {
+        if (item.1 == address and Time.now() >= item.2.start and Time.now() <= item.2.end) {
           return [(1, item.0)];
         };
       };

--- a/src/Sale/types.mo
+++ b/src/Sale/types.mo
@@ -7,6 +7,7 @@ import Shuffle "../Shuffle";
 import Tokens "../Tokens";
 import Disburser "../Disburser";
 import LedgerTypes "../Ledger/types";
+import Env "../Env"
 
 module {
 
@@ -16,7 +17,7 @@ module {
       _salesSettlementsState : [(AccountIdentifier, Sale)] = [];
       _failedSalesState : [(AccountIdentifier, SubAccount)] = [];
       _tokensForSaleState : [TokenIndex] = [];
-      _whitelistStable : [(Nat64, AccountIdentifier)] = [];
+      _whitelistStable : [(Nat64, AccountIdentifier, WhitelistSlot)] = [];
       _soldIcpState : Nat64 = 0;
       _soldState : Nat = 0;
       _totalToSellState : Nat = 0;
@@ -29,7 +30,7 @@ module {
     _salesSettlementsState : [(AccountIdentifier, Sale)];
     _failedSalesState : [(AccountIdentifier, SubAccount)];
     _tokensForSaleState : [TokenIndex];
-    _whitelistStable : [(Nat64, AccountIdentifier)];
+    _whitelistStable : [(Nat64, AccountIdentifier, WhitelistSlot)];
     _soldIcpState : Nat64;
     _soldState : Nat;
     _totalToSellState : Nat;
@@ -47,6 +48,8 @@ module {
     LEDGER_CANISTER : LedgerTypes.LEDGER_CANISTER;
     minter : Principal;
   };
+
+  public type WhitelistSlot = Env.WhitelistSlot;
 
   public type AccountIdentifier = ExtCore.AccountIdentifier;
 
@@ -67,8 +70,8 @@ module {
     price : Nat64;
     subaccount : SubAccount;
     buyer : AccountIdentifier;
-    whitelisted : Bool;
     expires : Time;
+    slot : ?WhitelistSlot;
   };
 
   public type SaleTransaction = {

--- a/test/.env.default.ts
+++ b/test/.env.default.ts
@@ -17,6 +17,10 @@ export default {
   publicSaleStart: BigInt(Date.now()) * 1_000_000n, // Start of first purchase (WL or other)
   whitelistTime: BigInt(Date.now()) * 1_000_000n, // Period for WL only discount. Set to publicSaleStart for no exclusive period
   marketDelay: 172_800_000_000_000n, // How long to delay market opening (2 days after whitelist sale started or when sold out)
+  whitelistSlot1_start: BigInt(Date.now()) * 1_000_000n,
+  whitelistSlot1_end: BigInt(Date.now()) * 1_000_000n,
+  whitelistSlot2_start: BigInt(Date.now()) * 1_000_000n,
+  whitelistSlot2_end: BigInt(Date.now()) * 1_000_000n,
   // true - assets will be revealed after manually calling 'shuffleAssets'
   // false - assets will be revealed immediately and assets shuffling will be disabled
   delayedReveal: true,

--- a/test/pending-sale/.env.pending-sale.ts
+++ b/test/pending-sale/.env.pending-sale.ts
@@ -4,4 +4,8 @@ export default {
   ...defaultEnv,
   publicSaleStart: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n, // Start of first purchase (WL or other)
   whitelistTime: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n, // Period for WL only discount. Set to publicSaleStart for no exclusive period
+  whitelistSlot1_start: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n,
+  whitelistSlot1_end: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n * 2n,
+  whitelistSlot2_start: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n,
+  whitelistSlot2_end: BigInt(new Date(2100, 1, 1).getTime()) * 1_000_000n * 2n,
 };

--- a/test/whitelist-sale/.env.whitelist-sale.ts
+++ b/test/whitelist-sale/.env.whitelist-sale.ts
@@ -4,4 +4,8 @@ export default {
   ...defaultEnv,
   publicSaleStart: BigInt(Date.now()) * 1_000_000n, // Start of first purchase (WL or other)
   whitelistTime: BigInt(Date.now()) * 1_000_000n * 2n, // Period for WL only discount. Set to publicSaleStart for no exclusive period
+  whitelistSlot1_start: BigInt(Date.now()) * 1_000_000n,
+  whitelistSlot1_end: BigInt(Date.now()) * 1_000_000n * 2n,
+  whitelistSlot2_start: BigInt(Date.now()) * 1_000_000n,
+  whitelistSlot2_end: BigInt(Date.now()) * 1_000_000n * 2n,
 };

--- a/test/whitelist-slots/.env.whitelist-slots.ts
+++ b/test/whitelist-slots/.env.whitelist-slots.ts
@@ -1,0 +1,11 @@
+import defaultEnv from '../.env.default';
+
+export default {
+  ...defaultEnv,
+  publicSaleStart: BigInt(Date.now()) * 1_000_000n, // Start of first purchase (WL or other)
+  whitelistTime: BigInt(Date.now()) * 1_000_000n * 2n, // Period for WL only discount. Set to publicSaleStart for no exclusive period
+  whitelistSlot1_start: BigInt(Date.now()) * 1_000_000n, // starts now
+  whitelistSlot1_end: BigInt(Date.now()) * 1_000_000n + 1_000_000n * 1000n * 60n, // 60s
+  whitelistSlot2_start: BigInt(Date.now()) * 1_000_000n + 1_000_000n * 1000n * 60n,
+  whitelistSlot2_end: BigInt(Date.now()) * 1_000_000n * 2n,
+};

--- a/test/whitelist-slots/whitelist-slots.test.ts
+++ b/test/whitelist-slots/whitelist-slots.test.ts
@@ -44,15 +44,15 @@ describe('whitelist slot 1', () => {
     let user = lucky[3];
     await user.mintICP(100_000_000_000n);
 
-    // tier 0 price
+    // tier 1 price
     let settings = await user.mainActor.salesSettings(user.accountId);
     expect(settings.price).toBe(env.whitelistTier0Price);
 
     await buyFromSale(user);
 
-    // tier 1 has not started so it should be sale price
+    // tier 2 price
     settings = await user.mainActor.salesSettings(user.accountId);
-    expect(settings.price).toBe(env.salePrice);
+    expect(settings.price).toBe(env.whitelistTier1Price);
   });
 
   test('try to buy after spot from slot 1 was used and slot 2 has not started yet', async () => {

--- a/test/whitelist-slots/whitelist-slots.test.ts
+++ b/test/whitelist-slots/whitelist-slots.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect } from 'vitest';
+import { User } from '../user';
+import { buyFromSale } from '../utils';
+import { whitelistTier0, whitelistTier1, lucky } from '../well-known-users';
+import env from './.env.whitelist-slots';
+
+// slot 1
+describe('whitelist slot 1', () => {
+  test('check price for non-whitelisted user', async () => {
+    let user = new User;
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.salePrice);
+  });
+
+  test('check whitelist price', async () => {
+    let user = whitelistTier0[0];
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.whitelistTier0Price);
+  });
+
+  test('check whitelist price after nft bought', async () => {
+    let user = whitelistTier0[1];
+    await user.mintICP(100_000_000_000n);
+
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.whitelistTier0Price);
+
+    await buyFromSale(user);
+
+    settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.salePrice);
+  });
+
+  test('check whitelist price for user from multiple whitelists', async () => {
+    let user = lucky[2];
+    await user.mintICP(100_000_000_000n);
+
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    // must be cheapest price
+    expect(settings.price).toBe(env.whitelistTier0Price);
+  });
+
+  test('check whitelist price change for user from multiple whitelists after multiple nft bought', async () => {
+    let user = lucky[3];
+    await user.mintICP(100_000_000_000n);
+
+    // tier 0 price
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.whitelistTier0Price);
+
+    await buyFromSale(user);
+
+    // tier 1 has not started so it should be sale price
+    settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.salePrice);
+  });
+
+  test('try to buy after spot from slot 1 was used and slot 2 has not started yet', async () => {
+    let user = lucky[3];
+
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    let res = await user.mainActor.reserve(settings.price, 1n, user.accountId, new Uint8Array);
+
+    expect(res).toHaveProperty('err');
+  });
+
+  test('user from slot 2 try to buy during slot 1', async () => {
+    let user = whitelistTier1[0];
+
+    let res = await user.mainActor.reserve(env.whitelistTier0Price, 1n, user.accountId, new Uint8Array);
+    expect(res).toHaveProperty('err');
+  });
+});
+
+// slot 2
+describe('whitelist slot 2', () => {
+  test('wait for slot 2 to start', async () => {
+    await new Promise<void>((resolve) => {
+      let interval = setInterval(() => {
+        if (Date.now() * 1_000_000 > env.whitelistSlot2_start) {
+          resolve();
+          clearInterval(interval);
+        }
+      }, 1000 * 5);
+    });
+  });
+
+  test('user from slot 1 try to buy during slot 2', async () => {
+    let user = whitelistTier0[4];
+    await user.mintICP(100_000_000_000n);
+
+    // should be sale price
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.salePrice);
+
+    let res = await user.mainActor.reserve(env.whitelistTier0Price, 1n, user.accountId, new Uint8Array);
+    expect(res).toHaveProperty('err');
+  });
+
+  test('user from both tiers bought during slot 1 and should be able to buy during slot 2', async () => {
+    let user = lucky[3];
+    await user.mintICP(100_000_000_000n);
+
+    // should be tier 2 price
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.whitelistTier1Price);
+
+    await buyFromSale(user);
+  });
+
+  test('user from both tiers did not buy during slot 1 and should be able to buy during slot 2 at tier 2 price', async () => {
+    let user = lucky[5];
+    await user.mintICP(100_000_000_000n);
+
+    // try to buy at tier 1 price
+    let res = await user.mainActor.reserve(env.whitelistTier0Price, 1n, user.accountId, new Uint8Array);
+    expect(res).toHaveProperty('err');
+
+    // should be tier 2 price
+    let settings = await user.mainActor.salesSettings(user.accountId);
+    expect(settings.price).toBe(env.whitelistTier1Price);
+
+    await buyFromSale(user);
+  });
+});


### PR DESCRIPTION
please add tests for
- [x] user has multiple wl spots in slot one, can he use all of them
- [ ] user has multiple wl spots in slot one, and multiple in slot two. make sure he can't use the spots in slot two, when he bought up all spots in slot one but we havent yet reached the start of slot two
- [x] user only has spots in slot two, make sure he can't buy during slot one
- [x] user only has spots in slot one, make sure he cant buy during slot two
- [x] user had spots in slot one, but didnt use them and spots in slot two. now we are in slot two, make sure the user only gets the slot two price
- [x] user is in two different WLs that are both in slot one but have different prices, make sure the users buys the cheapest one first